### PR TITLE
Added hecto discrete grid support to RoadSegment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,9 @@ gem 'haml'
 gem 'responders'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
+gem 'newrelic_rpm'
+gem 'dalli'
+
+group :test do
+  gem 'sqlite3'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1)
+    dalli (2.7.6)
     delayed_job (4.0.6)
       activesupport (>= 3.0, < 5.0)
     delayed_job_active_record (4.0.3)
@@ -75,6 +76,7 @@ GEM
     minitest (5.5.1)
     multi_json (1.11.0)
     multi_xml (0.5.5)
+    newrelic_rpm (3.16.3.323)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     pg (0.18.1)
@@ -126,6 +128,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -142,11 +145,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  dalli
   delayed_job
   delayed_job_active_record
   haml
   httparty
   jquery-rails
+  newrelic_rpm
   nokogiri
   pg
   polylines
@@ -154,6 +159,10 @@ DEPENDENCIES
   responders
   sass-rails (~> 5.0)
   serviceable
+  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   will_paginate
+
+BUNDLED WITH
+   1.13.2

--- a/README.rdoc
+++ b/README.rdoc
@@ -45,3 +45,25 @@ GET /road_segments?<options as follows>
   }
 
 Returns a set of road segments in the bounding box [38.84,-122.42,38.85,-122.41], up to a limit of 1000 per request.
+
+=== Discrete Grid Data
+
+GET /road_segments/:factor/:key
+
+where
+
+  factor is 1000, 10000, or 100000; representing a multiplier for lat/lng values; essentially, grid size
+
+  key is 10-byte string (30-bit base64 encoded) representation of the grid coordinates; details: https://cityhikerapp.com/2016/09/30/map-search-optimization/
+
+Returns a set of road segments encoded in 30-bit base64, packed as follows:
+
+	lat0
+	lng0
+	alt0
+	lat1
+	lng1
+	alt1
+	grade
+	guid
+

--- a/app/controllers/road_segments_controller.rb
+++ b/app/controllers/road_segments_controller.rb
@@ -4,6 +4,36 @@ class RoadSegmentsController < ApplicationController
   
   acts_as_service :road_segment
   
+  @@allowed_factors = [1000, 10000, 100000]
+  @@allowed_key_size = 10
+  
+  # required params:
+  #  factor: magnitude truncation factor; 1000 (default), 10000, or 100000
+  #  hecto_key: a 10-char base64 string encoding lat/lng
+  def hecto
+    # extract factor from params, if valid; default otherwise
+    if params[:factor] && @@allowed_factors.include?(params[:factor])
+      factor = params[:factor]
+    else
+      factor = 1000
+    end
+    
+    # extract key from params, if valid; return empty set otherwise
+    if params[:hecto_key] && params[:hecto_key].length == @@allowed_key_size
+      hecto_key = params[:hecto_key]
+
+      @collection = Rails.cache.fetch("#{factor}/#{hecto_key}", expires_in: 12.hours) do
+        RoadSegment.where(hecto_key: hecto_key)
+      end
+    else
+      @collection = []
+    end
+    
+    respond_to do |format|
+      format.json { render json: @collection.map(&:as_base64).to_json }
+    end
+  end
+  
   def did_assign_collection
     per_page = params[:per_page].to_i || 100 rescue 100
     per_page = 1000 if per_page > 1000 || per_page == 0

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,16 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :dalli_store,
+                      (ENV["MEMCACHIER_SERVERS"] || "").split(","),
+                      {
+                        :username => ENV["MEMCACHIER_USERNAME"],
+                        :password => ENV["MEMCACHIER_PASSWORD"],
+                        :failover => true,
+                        :socket_timeout => 1.5,
+                        :socket_failure_delay => 0.2,
+                        :down_retry_delay => 60
+                      }
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -1,0 +1,49 @@
+#
+# This file configures the New Relic Agent.  New Relic monitors Ruby, Java,
+# .NET, PHP, Python and Node applications with deep visibility and low
+# overhead.  For more information, visit www.newrelic.com.
+#
+# Generated October 02, 2016
+#
+# This configuration file is custom generated for app35259727@heroku.com
+#
+# For full documentation of agent configuration options, please refer to
+# https://docs.newrelic.com/docs/agents/ruby-agent/installation-configuration/ruby-agent-configuration
+
+common: &default_settings
+  # Required license key associated with your New Relic account.
+  license_key: 1b1204dd987633c29cd0d4552e5c276b43c9c09f
+
+  # Your application name. Renaming here affects where data displays in New
+  # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
+  app_name: CityHiker
+
+  # To disable the agent regardless of other settings, uncomment the following:
+  # agent_enabled: false
+
+  # Logging level for log/newrelic_agent.log
+  log_level: info
+
+
+# Environment-specific settings are in this section.
+# RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
+# If your application has other named environments, configure them here.
+development:
+  <<: *default_settings
+  app_name: CityHiker (Development)
+
+  # NOTE: There is substantial overhead when running in developer mode.
+  # Do not use for production or load testing.
+  developer_mode: true
+
+test:
+  <<: *default_settings
+  # It doesn't make sense to report to New Relic from automated test runs.
+  monitor_mode: false
+
+staging:
+  <<: *default_settings
+  app_name: CityHiker (Staging)
+
+production:
+  <<: *default_settings

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :grid_requests, only: [:create,:show,:index]
   
   get 'differential/search' => 'differential#search'
+  get 'road_segments/:factor/:hecto_key' => 'road_segments#hecto'
   
   root to: 'welcome#index'
 end

--- a/db/migrate/20161002003837_add_hecto_key_to_road_segments.rb
+++ b/db/migrate/20161002003837_add_hecto_key_to_road_segments.rb
@@ -1,0 +1,12 @@
+class AddHectoKeyToRoadSegments < ActiveRecord::Migration
+  def change
+    add_column :road_segments, :hecto_key, :string, limit: 10
+    add_index :road_segments, [ :hecto_key ], name: 'index_road_segments_on_hecto_key'
+    
+    # generate hecto key and update record
+    RoadSegment.find_each do |segment|
+      segment.generate_hecto_key
+      segment.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150326164454) do
+ActiveRecord::Schema.define(version: 20161002003837) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,9 @@ ActiveRecord::Schema.define(version: 20150326164454) do
     t.float    "percent_grade"
     t.datetime "created_at",    null: false
     t.datetime "updated_at",    null: false
+    t.string   "hecto_key"
   end
+
+  add_index "road_segments", ["hecto_key"], name: "index_road_segments_on_hecto_key", using: :btree
 
 end

--- a/test/models/road_segment_test.rb
+++ b/test/models/road_segment_test.rb
@@ -1,7 +1,11 @@
 require 'test_helper'
 
 class RoadSegmentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+
+  def test_float_to_int26
+    iVal = RoadSegment.float_to_int26(38.86543, 100000)
+    sVal = RoadSegment.int26_to_base64(iVal)
+    assert_equal("ao03p", sVal)
+  end
+
 end


### PR DESCRIPTION
Added hecto_key to RoadSegment model and configured an index on it.

Exposed new endpoint  `road_segments/:factor/:key`  to enable discrete
grid querying of segment data. The factor is 1000, 10000, or 100000;
representing a multiplier on lat/lng. The key is a pair of 30-bit
base64 encoded strings;lat and lng, respectively.

Enabled NewRelic monitoring and MemCachier caching via dalli gem.

Encoding strategy described in detail here: https://cityhikerapp.com/2016/09/30/map-search-optimization/
